### PR TITLE
Fix permissions of API routes and stop exposing password hash

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/PatronController.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/PatronController.pm
@@ -51,8 +51,7 @@ sub check_status {
     my $patron_id = $c->validation->param('patron_id');
     my $patron    = Koha::Patrons->find($patron_id);
 
-    my $plugin = Koha::Plugin::Com::ByWaterSolutions::BatchPermissionsModifier->new();
-    my $data = $plugin->check_patron_status( { borrowernumber => $patron_id } );
+    my $data = $c->check_patron_status( { borrowernumber => $patron_id } );
 
     unless ($patron) {
         return $c->render( status => 404, openapi => { error => "Patron not found." } );
@@ -75,6 +74,70 @@ sub check_list {
 #    }
 
     return $c->render( status => 200, openapi => { success => Mojo::JSON->true } );
+}
+
+sub check_patron_status {
+    my ( $c, $params ) = @_;
+    my $borrowernumber = $params->{borrowernumber};
+
+    my $dbh = C4::Context->dbh;
+
+    my $plugin = Koha::Plugin::Com::ByWaterSolutions::BatchPermissionsModifier->new();
+    my @pairs = split(/\r?\n/, $plugin->retrieve_data('template_permission_mappings') );
+
+    # Check to see if patron is a template patron, if so, update the permissions
+    # of all patrons in lists mapped to that patron
+    my $is_template_patron;
+    my @patron_list_ids;
+    foreach my $pair ( @pairs ) {
+        my ( $template_borrowernumber, $patron_list_id ) = split(/:[[:blank:]]{0,1}/, $pair );
+        push( @patron_list_ids, $patron_list_id ) if ( $borrowernumber eq $template_borrowernumber );
+    }
+
+    my $data = {
+        is_template_patron => 0,
+    };
+
+    if (@patron_list_ids) {
+        $data->{is_template_patron} = 1;
+        $data->{patron_lists}       = [
+            Koha::Database->new()->schema->resultset('PatronList')->search(
+                { patron_list_id => { -in => \@patron_list_ids } },
+                { result_class => 'DBIx::Class::ResultClass::HashRefInflator' }
+            )->all
+        ];
+    }
+    else {
+
+        foreach my $pair (@pairs) {
+            my ( $template_borrowernumber, $patron_list_id ) =
+              split( /:[[:blank:]]{0,1}/, $pair );
+
+            my $count = $dbh->do(
+                "SELECT borrowernumber FROM patron_list_patrons WHERE patron_list_id = ? AND borrowernumber = ?",
+                undef,
+                ( $patron_list_id, $borrowernumber )
+            );
+
+            if ( $count eq '1' ) {
+                $data->{patron_list} =
+                  Koha::Database->new()->schema->resultset('PatronList')->find(
+                    $patron_list_id,
+                    {
+                        result_class =>
+                          'DBIx::Class::ResultClass::HashRefInflator'
+                    }
+                  );
+
+                my $template_patron = Koha::Patrons->find($template_borrowernumber);
+                $data->{template_patron} = $c->objects->to_api($template_patron);
+
+                last;
+            }
+        }
+    }
+
+    return $data;
 }
 
 1;

--- a/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/intranetuserjs.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/intranetuserjs.tt
@@ -37,7 +37,7 @@ $(document).ready(function() {
 
       } else {
         if (data.patron_list) {
-          form.insertAdjacentHTML("beforebegin", "<h1>This patron's permissions are controlled by the permissions template patron <a href='/cgi-bin/koha/members/moremember.pl?borrowernumber=" + data.template_patron.borrowernumber + "'>" + data.template_patron.surname + "</a></h1>");
+          form.insertAdjacentHTML("beforebegin", "<h1>This patron's permissions are controlled by the permissions template patron <a href='/cgi-bin/koha/members/moremember.pl?borrowernumber=" + data.template_patron.patron_id + "'>" + data.template_patron.surname + "</a></h1>");
           $('#permissions_toolbar, #flag_form h1').remove();
           $('#permissionstree input').attr('disabled','disabled');
         }

--- a/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/openapi.json
+++ b/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier/openapi.json
@@ -30,6 +30,11 @@
                 }
           }
         }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "edit_borrowers"
+        }
       }
     }
   },
@@ -64,6 +69,11 @@
                 }
           }
         }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "edit_borrowers"
+        }
       }
     }
   },
@@ -97,6 +107,11 @@
                   }
                 }
           }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "edit_borrowers"
         }
       }
     }


### PR DESCRIPTION
API routes were public and allowed anyone to fetch informations about template patrons (including their password hash) and to trigger batch permissions modifications.

Now all API routes require user to be authenticated and to have permission 'edit_borrowers'.

check_status route now uses $c->objects->to_api to avoid exposing sensitive information, like the password hash