### PR TITLE
Make batch-permissions-modifier an Admin tool plugin

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/BatchPermissionsModifier.pm
@@ -86,7 +86,7 @@ sub api_namespace {
     return 'bpm';
 }
 
-sub tool {
+sub admin {
     my ( $self, $args ) = @_;
 
     my $cgi = $self->{'cgi'};


### PR DESCRIPTION
Since bug 36206 plugins can be configured to run as an admin only tool.

This patch changes the plugin method from 'tool' to 'admin' so that it is no longer exposed under the Tools module.

This would allow for administrators to give library staff permissions to run other less sensitive tool plugins like Label Maker without providing access to batch modify permissions.

To test:
- Apply patch and install plugin
- Login as superlibrarian                              
- Notice the plugin is not listed under Tools anymore
- Notice the plugin is listed under Admin > Plugins